### PR TITLE
Fix React.PropTypes deprecation warning

### DIFF
--- a/example/src/components/ControlsPane/ControlsPane.js
+++ b/example/src/components/ControlsPane/ControlsPane.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Sticky } from 'react-sticky';
 import { findDOMNode } from 'react-dom';
 import classNames from 'classnames/bind';

--- a/example/src/components/Gif/Gif.js
+++ b/example/src/components/Gif/Gif.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 
 import styles from './Gif.scss';

--- a/example/src/components/GifGrid/GifGrid.js
+++ b/example/src/components/GifGrid/GifGrid.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 
 import Gif from 'components/Gif';

--- a/example/src/components/Github/Github.js
+++ b/example/src/components/Github/Github.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 
 import styles from './Github.scss';

--- a/example/src/components/Header/Header.js
+++ b/example/src/components/Header/Header.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 
 import Github from 'components/Github';

--- a/example/src/components/Layout/Layout.js
+++ b/example/src/components/Layout/Layout.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import styles from './Layout.scss';
 
 export default function Layout({ children }) {

--- a/example/src/components/TasksBubble/TasksBubble.js
+++ b/example/src/components/TasksBubble/TasksBubble.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Sticky } from 'react-sticky';
 import classNames from 'classnames/bind';
 

--- a/example/src/containers/App.js
+++ b/example/src/containers/App.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { StickyContainer } from 'react-sticky';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';

--- a/package.json
+++ b/package.json
@@ -34,12 +34,16 @@
   ],
   "author": "Alexander Uspensy <aeuspensky@gmail.com>",
   "license": "MIT",
+  "dependencies": {
+    "prop-types": "^15.5.10"
+  },
   "peerDependencies": {
-    "react": "^0.14.7 || ^15.3.1",
-    "react-dom": "^0.14.7 || ^15.3.1",
+    "react": "^0.14.9 || ^15.3.1",
+    "react-dom": "^0.14.9 || ^15.3.1",
     "nprogress": "^0.2.0"
   },
   "devDependencies": {
+    "babel-cli": "^6.24.1",
     "babel-core": "^6.11.4",
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-object-rest-spread": "^6.8.0",

--- a/src/NProgressComponent.js
+++ b/src/NProgressComponent.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { renderToString } from 'react-dom/server';
 import { connect } from 'react-redux'
 import NProgress from 'nprogress';

--- a/src/NProgressTemplate.js
+++ b/src/NProgressTemplate.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 /* TODO.
 


### PR DESCRIPTION
@jaredt67 thanks for making a thoughtful and useful package.

This PR was originally made to fix #3 

## Includes the following changes
- [x] install prop-types package as dependency per [prop-types - How to depend on this package](https://github.com/facebook/prop-types#how-to-depend-on-this-package)
- [x] change all instances of React.PropTypes to use from prop-types package - including in the [example code](../tree/master/example)
- [x] Updated peerDepency on react & react-dom to ^0.14.9 per [prop-types - Compatibility](https://github.com/facebook/prop-types#compatibility)
- [x] Added babel-cli as devDependency for building instead of relying on global install of `babel-cli`